### PR TITLE
Prevent TypeError on `<style>` tags

### DIFF
--- a/include.js
+++ b/include.js
@@ -199,7 +199,7 @@
 
         // loop on document stylesheets to check if media is loaded
         while (i--) {
-            if (sheets[i].href.indexOf(href) != -1) {
+            if (sheets[i].href && sheets[i].href.indexOf(href) != -1) {
                 elem.setAttribute('data-loaded', true);
                 self.onModuleLoaded(elem.getAttribute('data-module'), elem.getAttribute('data-count'));
                 return;


### PR DESCRIPTION
document.styleSheets contains both `<link rel="stylesheet">` and `<style>`  elements; since the later have `href = null`, it would throw a TypeError.